### PR TITLE
Fix issue: CodedInputStream constructor does not check for int overflow.

### DIFF
--- a/src/google/protobuf/message_lite.cc
+++ b/src/google/protobuf/message_lite.cc
@@ -327,6 +327,7 @@ bool MessageLite::ParsePartialFromString(const std::string& data) {
 }
 
 bool MessageLite::ParseFromArray(const void* data, int size) {
+  if (size < 0) return false;  // security: size is often user-supplied 
   return ParseFrom<kParse>(as_string_view(data, size));
 }
 

--- a/src/google/protobuf/message_unittest.inc
+++ b/src/google/protobuf/message_unittest.inc
@@ -386,6 +386,16 @@ TEST(MESSAGE_TEST_NAME, ParseFailsOnInvalidMessageEnd) {
   EXPECT_FALSE(message.ParseFromArray("\014", 1));
 }
 
+TEST(MESSAGE_TEST_NAME, ParseFailsOnInvalidBufferSize) {
+  UNITTEST::TestAllTypes message;
+
+  // The buffer size is a negative number.
+  EXPECT_FALSE(message.ParseFromArray("", -1));
+
+  // The buffer size is a very large number which over INT_MAX.
+  EXPECT_FALSE(message.ParseFromArray("", 2147483648));
+}
+
 // Regression test for b/23630858
 TEST(MESSAGE_TEST_NAME, MessageIsStillValidAfterParseFails) {
   UNITTEST::TestAllTypes message;


### PR DESCRIPTION
This PR fix  issue : check the parameter of  ParseFromArray(const void* data, int size), if  user supply a negative number or a very large number which over INT_MAX, then return false.  In the message_unittest.inc file，a test case "TEST(MESSAGE_TEST_NAME, ParseFailsOnInvalidBufferSize)" is added to verify it.